### PR TITLE
Include empty .venv directory

### DIFF
--- a/.venv/.gitignore
+++ b/.venv/.gitignore
@@ -1,0 +1,2 @@
+# created by virtualenv automatically
+*


### PR DESCRIPTION
Creates a nominally empty .venv directory so pipenv defaults to creating the venv in-project